### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Python Package using Conda
 
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/B-HDtm/NeXT/security/code-scanning/3](https://github.com/B-HDtm/NeXT/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow file. Since the workflow only checks out code and runs tests, it only needs read access to the repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name` and before the `on` key. This will ensure that all jobs in the workflow inherit these minimal permissions unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
