### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-ant
 
 name: Java CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/B-HDtm/NeXT/security/code-scanning/2](https://github.com/B-HDtm/NeXT/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code and builds with Ant, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` field and before the `on` field. This will apply the restriction to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
