### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: NodeJS with Grunt
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/B-HDtm/NeXT/security/code-scanning/1](https://github.com/B-HDtm/NeXT/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code and runs build steps, it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the top level of the workflow (just after the `name:` and before `on:`), setting `contents: read`. This will apply to all jobs in the workflow unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
